### PR TITLE
Added Mark Question/Answer Helpful Functionality 

### DIFF
--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -161,6 +161,8 @@ Questions & Answers
 .qaComponent {
   position: relative;
   left: 15%;
+  max-height: 85vh;
+  overflow: scroll;
 }
 
 .qaSearch {

--- a/client/src/components/QA/QuestionItem.jsx
+++ b/client/src/components/QA/QuestionItem.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import moment from 'moment';
 
-const QuestionItem = ({ question, answerLimit }) => {
+const QuestionItem = ({ question, answerLimit, questionId, markQuestionHelpful, markAnswerHelpful }) => {
   let container = [];
 
   for (let answerId in question.answers) {
@@ -15,7 +15,7 @@ const QuestionItem = ({ question, answerLimit }) => {
     <div className="questionItem">
       <div id="questionHeader">
         <div className="questionText">Q: {question.question_body}</div>
-        <div className="questionStats">Helpful? &nbsp; <span className="clickable" style={ {textDecoration: 'underline'} }>Yes</span>({question.question_helpfulness})&nbsp; | &nbsp;<span className="clickable" style={ {textDecoration: 'underline'} }>Add Answer</span></div>
+        <div className="questionStats">Helpful? &nbsp; <span id={questionId} onClick={markQuestionHelpful} className="clickable" style={ {textDecoration: 'underline'} }>Yes</span>({question.question_helpfulness})&nbsp; | &nbsp;<span className="clickable" style={ {textDecoration: 'underline'} }>Add Answer</span></div>
       </div>
       <div>
         {sortedContainer
@@ -26,7 +26,7 @@ const QuestionItem = ({ question, answerLimit }) => {
                 A: {answer[1].body}
                 <br/>
                 by {answer[1].answerer_name}, {moment(answer[1].date).format('MMM Do YYYY')}
-                &nbsp; | &nbsp; Helpful? &nbsp; <span style={ {textDecoration: 'underline'} }>Yes</span>({answer[1].helpfulness}) &nbsp; | &nbsp; <span style={ {textDecoration: 'underline'} }>{answer[1].reported ? 'Reported' : 'Report'}</span>
+                &nbsp; | &nbsp; Helpful? &nbsp; <span className="clickable" style={ {textDecoration: 'underline'} } onClick={markAnswerHelpful} id={answer[1].id}>Yes</span>({answer[1].helpfulness}) &nbsp; | &nbsp; <span style={ {textDecoration: 'underline'} }>{answer[1].reported ? 'Reported' : 'Report'}</span>
               </p>
             );
           })}

--- a/client/src/components/QA/QuestionList.jsx
+++ b/client/src/components/QA/QuestionList.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import QuestionItem from './QuestionItem.jsx'
+import React from "react";
+import QuestionItem from "./QuestionItem.jsx";
 
 const QuestionList = (props) => {
   let sorted = props.questions.sort((a, b) => {
@@ -8,17 +8,22 @@ const QuestionList = (props) => {
 
   return (
     <div>
-      {
-        sorted.map(question => {
-          return (
-            <QuestionItem question={question} answerLimit={props.answerLimit} key={question.question_id}/>
-          );
-        })
-      }
+      {sorted.map((question) => (
+        <QuestionItem
+          question={question}
+          answerLimit={props.answerLimit}
+          key={question.question_id}
+          questionId={question.question_id}
+          markQuestionHelpful={props.markQuestionHelpful}
+          markAnswerHelpful={props.markAnswerHelpful}
+        />
+      ))}
       <button onClick={props.showQuestion}>Add A Question</button>
-      <button className="moreQuestionButton" onClick={props.onClick}>More Answered Questions</button>
+      <button className="moreQuestionButton" onClick={props.onClick}>
+        More Answered Questions
+      </button>
     </div>
   );
-}
+};
 
 export default QuestionList;

--- a/client/src/components/QA/QuestionView.jsx
+++ b/client/src/components/QA/QuestionView.jsx
@@ -25,6 +25,9 @@ class QuestionView extends React.Component {
     this.loadMoreQuestions = this.loadMoreQuestions.bind(this);
     this.showAddQuestion = this.showAddQuestion.bind(this);
     this.closeAddQuestion = this.closeAddQuestion.bind(this);
+    this.getCurrentQuestions = this.getCurrentQuestions.bind(this);
+    this.markQuestionHelpful = this.markQuestionHelpful.bind(this);
+    this.markAnswerHelpful = this.markAnswerHelpful.bind(this);
   }
 
   componentDidUpdate(prevProps) {
@@ -97,6 +100,24 @@ class QuestionView extends React.Component {
     })
   }
 
+  markQuestionHelpful(event) {
+    axios.put(`https://app-hrsei-api.herokuapp.com/api/fec2/hr-nyc/qa/questions/${event.target.id}/helpful`, { question_id: event.target.id}, { headers: {Authorization: API_KEY}})
+    .then((res) => console.log(res))
+    .then(() => {
+      this.getCurrentQuestions(this.props.productId);
+    })
+    .catch((err) => { throw err; });
+  }
+
+  markAnswerHelpful(event) {
+    axios.put(`https://app-hrsei-api.herokuapp.com/api/fec2/hr-nyc/qa/answers/${event.target.id}/helpful`, { question_id: event.target.id}, { headers: {Authorization: API_KEY}})
+    .then((res) => console.log(res))
+    .then(() => {
+      this.getCurrentQuestions(this.props.productId);
+    })
+    .catch((err) => { throw err; });
+  }
+
 
   render() {
     if (!this.state.currentProductQuestions) {
@@ -108,7 +129,7 @@ class QuestionView extends React.Component {
         <div data-testid='question-view' className="qaComponent">
           <h2>Questions & Answers</h2>
           <QuestionSearch onSearch={this.searchQuestionList}/>
-          <QuestionList questions={this.state.searchedQuestions} answerLimit={this.state.shownAnswers} onClick={this.loadMoreQuestions} showQuestion={this.showAddQuestion}/>
+          <QuestionList questions={this.state.searchedQuestions} answerLimit={this.state.shownAnswers} onClick={this.loadMoreQuestions} showQuestion={this.showAddQuestion} markQuestionHelpful={this.markQuestionHelpful} markAnswerHelpful={this.markAnswerHelpful}/>
           <AddQuestion addQuestion={this.handleAddQuestion} visible={this.state.addQuestionVisisble} onClick={this.closeAddQuestion}/>
           <AddAnswer />
         </div>


### PR DESCRIPTION
These two functions are essentially the same. I added an 'ID' prop to the spans that we'll be clicking on and set the ID to the corresponding question or answer ID. I then passed that prop to a function that executes a PUT request on the API at either the /qa/questions/id/helpful or /qa/answers/id/helpful path, incrementing the helpful counter. Upon completion (in both functions) I call the getCurrentQuestions method to rerender QuestionList with the updated data.