### PR TITLE
added fontawesome

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
     "axios": "^0.24.0",
     "moment": "^2.29.1",
     "react": "^15.6.0",
-    "react-dom": "^15.6.0"
+    "react-dom": "^15.6.0",
+    "@fortawesome/fontawesome-svg-core": "^1.2.36",
+    "@fortawesome/free-brands-svg-icons": "^5.15.4",
+    "@fortawesome/free-regular-svg-icons": "^5.15.4",
+    "@fortawesome/free-solid-svg-icons": "^5.15.4",
+    "@fortawesome/react-fontawesome": "^0.1.16"
   }
 }


### PR DESCRIPTION
@kyelindholm @ks10825n 

- Added fontawesome for react
- How to use: https://fontawesome.com/v5.15/how-to-use/on-the-web/using-with/react

I am thinking we can use the "Individual Use" option, where you only import the icons that you need instead of the entire library of icons available, since we probably don't need that many and it's better for performance