### PR TITLE
Implemented Add Answer

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -54,7 +54,7 @@ class App extends React.Component {
       <div>
         <NavBar />
         <Overview currentProduct={this.state.currentProduct} ratings={this.state.productRatings.ratings}/>
-        <QuestionView productId={this.state.currentProduct.id}/>
+        <QuestionView productId={this.state.currentProduct.id} productName={this.state.currentProduct.name}/>
         <RatingsAndReviews
           currentProduct={this.state.currentProduct}
           productRatings={this.state.productRatings}

--- a/client/src/components/QA/AddAnswer.jsx
+++ b/client/src/components/QA/AddAnswer.jsx
@@ -5,15 +5,60 @@ class AddAnswer extends React.Component {
     super(props);
 
     this.state = {
-
+      answer: '',
+      username: '',
+      email: '',
+      images: [],
+      questionId: props.questionId
     };
+
+    this.onChangeAnswer = this.onChangeAnswer.bind(this);
+    this.onChangeUsername = this.onChangeUsername.bind(this);
+    this.onChangeEmail = this.onChangeEmail.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+  }
+
+  onChangeAnswer(e) {
+    this.setState({
+      answer: e.target.value
+    });
+  }
+
+  onChangeUsername(e) {
+    this.setState({
+      username: e.target.value
+    });
+  }
+
+  onChangeEmail(e) {
+    this.setState({
+      email: e.target.value
+    });
+  }
+
+  onSubmit(e) {
+    e.preventDefault();
+    this.props.onSubmit(this.state)
   }
 
 
 
   render() {
     return (
-      <div></div>
+      <form id="modal" className="addQuestionForm" onSubmit={this.onSubmit} style={ {visibility: Number(this.props.addAnswerTo) === Number(this.props.questionId) ? 'visible' : 'hidden' }}>
+        <h3 className="addQuestionTitle">Submit Your Answer</h3>
+        <h2 style={ {fontSize: '12px'} }>{this.props.productName}: &nbsp; {this.props.questionBody}</h2>
+        <span className="closeForm" onClick={this.props.onClick}>x</span>
+        <label htmlFor="answer">Answer:</label>
+        <textarea name="answer" maxLength="1000" value={this.state.answer} onChange={this.onChangeAnswer}required/>
+        <label htmlFor="username">Username: </label>
+        <input type="text" value={this.state.username} onChange={this.onChangeUsername} name="username" maxLength="60" placeholder="Example: jack543!" required />
+        <p className="addQuestionInput" style={{ fontSize: "8px", marginTop: '0', color: 'white', position: 'relative', marginLeft: '0',}}>For privacy reasons, do not use your full name or email address within nickname.</p>
+        <label htmlFor="username">Email: </label>
+        <input type="email" value={this.state.email} onChange={this.onChangeEmail} name="email" maxLength="60" placeholder="Example: jack@email.com" required />
+        <input type="file" accept="image/png, image/jpeg"/>
+        <input type="submit" />
+      </form>
     );
   }
 }

--- a/client/src/components/QA/AddQuestion.jsx
+++ b/client/src/components/QA/AddQuestion.jsx
@@ -48,10 +48,10 @@ class AddQuestion extends React.Component {
       <form id="modal" className="addQuestionForm" onSubmit={this.handleSubmit} style={ {visibility: this.props.visible} }>
         <span className="closeForm" onClick={this.props.onClick}>x</span>
         <h3 className="addQuestionTitle">Add Question</h3>
-        <textarea className="addQuestionInput" placeholder="Your question..." onChange={this.onChangeQuestion} value={this.state.question}/>
-        <input className="addQuestionInput" type="text" placeholder="Nickname..." value={this.state.nickname} onChange={this.onChangeNickname}/>
+        <textarea className="addQuestionInput" placeholder="Your question..." maxLength="1000" onChange={this.onChangeQuestion} value={this.state.question}required/>
+        <input className="addQuestionInput" type="text" placeholder="Nickname..." value={this.state.nickname} onChange={this.onChangeNickname} required/>
         <p className="addQuestionInput" style={{ fontSize: "8px", marginTop: '0', color: 'white' }}>For privacy reasons, do not use your full name or email address within nickname.</p>
-        <input className="addQuestionInput" type="email"  placeholder="Email..." value={this.state.email} onChange={this.onChangeEmail}/>
+        <input className="addQuestionInput" type="email"  placeholder="Email..." value={this.state.email} onChange={this.onChangeEmail} required/>
         <input className="addQuestionInput" id="addQuestionSubmit" type="submit"/>
       </form>
     );

--- a/client/src/components/QA/QuestionItem.jsx
+++ b/client/src/components/QA/QuestionItem.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import moment from "moment";
+import AddAnswer from './AddAnswer.jsx';
 
 const QuestionItem = ({
   question,
@@ -9,6 +10,13 @@ const QuestionItem = ({
   markAnswerHelpful,
   reportAnswer,
   answerReported,
+  productName,
+  addAnswerTo,
+  showAddAnswer,
+  closeAddAnswer,
+  handleSubmitAnswer,
+  showMoreAnswers,
+  showLessAnswers
 }) => {
   let container = [];
 
@@ -19,6 +27,8 @@ const QuestionItem = ({
   let sortedContainer = container.sort((a, b) => {
     return b[1].helpfulness - a[1].helpfulness;
   });
+
+
   return (
     <div className="questionItem">
       <div id="questionHeader">
@@ -34,7 +44,7 @@ const QuestionItem = ({
             Yes
           </span>
           ({question.question_helpfulness})&nbsp; | &nbsp;
-          <span className="clickable" style={{ textDecoration: "underline" }}>
+          <span id={questionId} className="clickable" style={{ textDecoration: "underline" }} onClick={showAddAnswer}>
             Add Answer
           </span>
         </div>
@@ -73,6 +83,8 @@ const QuestionItem = ({
           );
         })}
       </div>
+      <span style={ {fontWeight: '550', textDecoration: 'underline'} } className='clickable' onClick={sortedContainer.slice(0, answerLimit).length < sortedContainer.length ? () => { showMoreAnswers(sortedContainer.length) } : showLessAnswers }>{sortedContainer.slice(0, answerLimit).length < sortedContainer.length ? 'See More Answers' : sortedContainer.slice(0, answerLimit).length > 2 ? 'Collapse Answers' : ''}</span>
+      <AddAnswer questionId={questionId} productName={productName} questionBody={question.question_body} addAnswerTo={addAnswerTo} onClick={closeAddAnswer} onSubmit={handleSubmitAnswer}/>
     </div>
   );
 };

--- a/client/src/components/QA/QuestionList.jsx
+++ b/client/src/components/QA/QuestionList.jsx
@@ -19,6 +19,13 @@ const QuestionList = (props) => {
           markAnswerHelpful={props.markAnswerHelpful}
           reportAnswer= {props.reportAnswer}
           answerReported={props.answerReported}
+          productName={props.productName}
+          addAnswerTo={props.addAnswerTo}
+          showAddAnswer={props.showAddAnswer}
+          closeAddAnswer={props.closeAddAnswer}
+          handleSubmitAnswer={props.handleSubmitAnswer}
+          showMoreAnswers={props.showMoreAnswers}
+          showLessAnswers={props.showLessAnswers}
         />
       ))}
       <button onClick={props.showQuestion}>Add A Question</button>

--- a/client/src/components/QA/QuestionView.jsx
+++ b/client/src/components/QA/QuestionView.jsx
@@ -19,7 +19,8 @@ class QuestionView extends React.Component {
       shownAnswers: 2,
       addQuestionVisisble: 'hidden',
       moreQuestionsVisible: 'visible',
-      answerReported: []
+      answerReported: [],
+      addAnswerTo: 0
     };
 
     this.handleAddQuestion = this.handleAddQuestion.bind(this);
@@ -31,6 +32,11 @@ class QuestionView extends React.Component {
     this.markQuestionHelpful = this.markQuestionHelpful.bind(this);
     this.markAnswerHelpful = this.markAnswerHelpful.bind(this);
     this.reportAnswer = this.reportAnswer.bind(this);
+    this.showAddAnswer = this.showAddAnswer.bind(this);
+    this.closeAddAnswer = this.closeAddAnswer.bind(this);
+    this.handleSubmitAnswer = this.handleSubmitAnswer.bind(this);
+    this.showMoreAnswers = this.showMoreAnswers.bind(this);
+    this.showLessAnswers = this.showLessAnswers.bind(this);
   }
 
   componentDidUpdate(prevProps) {
@@ -44,7 +50,7 @@ class QuestionView extends React.Component {
   }
 
 
-  getCurrentQuestions(id) {
+  getCurrentQuestions(id){
     axios.get('https://app-hrsei-api.herokuapp.com/api/fec2/hr-nyc/qa/questions', { headers: {Authorization: API_KEY}, params: {product_id: id, count: this.state.shownQuestions}})
       .then((response) => {
         if ((response.data.results.length > 4) && (JSON.stringify(response.data.results) === JSON.stringify(this.state.currentProductQuestions))) {
@@ -139,6 +145,35 @@ class QuestionView extends React.Component {
     .catch((err) => { throw err; });
   }
 
+  showAddAnswer(event) {
+    this.setState({addAnswerTo: event.target.id });
+  }
+
+  closeAddAnswer() {
+    this.setState({ addAnswerTo: 0 });
+  }
+
+  handleSubmitAnswer(answer) {
+    axios.post(`https://app-hrsei-api.herokuapp.com/api/fec2/hr-nyc/qa/questions/${answer.questionId}/answers`, { body: answer.answer, name: answer.username, email: answer.email, photos: answer.images}, {headers: {Authorization: API_KEY}})
+    .then(res => console.log(res))
+    .then(() => {
+      this.getCurrentQuestions(this.state.currentProductId);
+    })
+    .catch((err) => { throw err; });
+  }
+
+  showMoreAnswers(len) {
+    this.setState({
+      shownAnswers: len
+    });
+  }
+
+  showLessAnswers() {
+    this.setState({
+      shownAnswers: 2
+    });
+  }
+
 
   render() {
     if (!this.state.currentProductQuestions) {
@@ -150,9 +185,8 @@ class QuestionView extends React.Component {
         <div data-testid='question-view' className="qaComponent">
           <h2>Questions & Answers</h2>
           <QuestionSearch onSearch={this.searchQuestionList}/>
-          <QuestionList questions={this.state.searchedQuestions} answerLimit={this.state.shownAnswers} onClick={this.loadMoreQuestions} showQuestion={this.showAddQuestion} markQuestionHelpful={this.markQuestionHelpful} markAnswerHelpful={this.markAnswerHelpful} visible={this.state.moreQuestionsVisible} reportAnswer={this.reportAnswer} answerReported={this.state.answerReported}/>
+          <QuestionList questions={this.state.searchedQuestions} answerLimit={this.state.shownAnswers} onClick={this.loadMoreQuestions} showQuestion={this.showAddQuestion} markQuestionHelpful={this.markQuestionHelpful} markAnswerHelpful={this.markAnswerHelpful} visible={this.state.moreQuestionsVisible} reportAnswer={this.reportAnswer} answerReported={this.state.answerReported} productName={this.props.productName} addAnswerTo={this.state.addAnswerTo} showAddAnswer={this.showAddAnswer} closeAddAnswer={this.closeAddAnswer} handleSubmitAnswer={this.handleSubmitAnswer} showMoreAnswers={this.showMoreAnswers} showLessAnswers={this.showLessAnswers}/>
           <AddQuestion addQuestion={this.handleAddQuestion} visible={this.state.addQuestionVisisble} onClick={this.closeAddQuestion}/>
-          <AddAnswer />
         </div>
       </div>
     );


### PR DESCRIPTION
Hey guys!

Kind of a big one so I'll make sure to go over everything in here. 

The AddAnswer modal is stylistically similar to the AddQuestion modal. When we click on 'Add Question' we'll make the modal visible and render the name of the product/the question itself as a subheader within the modal form. Additionally, we're passing the question's ID to the state of the modal component when we click. 

Otherwise, the modal functionality is the same as AddQuestion's, in that we're committing a POST request to the answers API upon form submission, passing the state from the modal module (which itself is set whenever we type into the modal). This is a little buggy in that it seems to be rendering additional questions on the re-render, which is confusing because I'm using the same re-render implementation as when we increment a question's helpfulness, which re-renders appropriately. Something to go back into and fix, I guess. 

I also implemented a "See More Answers" span that'll appear if there are more than 2 answers to a question (the default limit is 2). When clicked, we'll show every answer to that question and the span will change to read "Collapse Answers". When we click on this, it'll return to rendering 2 answers. If there are only two answers to a question then they'll both be rendered (as per the limit) and there will be no span visible. This is all handled with a nested ternary operator and a couple of simple setstate methods.