### PR TITLE
fixed See More Answers bug

### DIFF
--- a/client/src/components/QA/QuestionItem.jsx
+++ b/client/src/components/QA/QuestionItem.jsx
@@ -16,7 +16,8 @@ const QuestionItem = ({
   closeAddAnswer,
   handleSubmitAnswer,
   showMoreAnswers,
-  showLessAnswers
+  showLessAnswers,
+  expandAnswers
 }) => {
   let container = [];
 
@@ -27,6 +28,9 @@ const QuestionItem = ({
   let sortedContainer = container.sort((a, b) => {
     return b[1].helpfulness - a[1].helpfulness;
   });
+
+  let answerContainer = expandAnswers.includes(Number(questionId)) ? sortedContainer : sortedContainer.slice(0, answerLimit);
+
 
 
   return (
@@ -50,7 +54,7 @@ const QuestionItem = ({
         </div>
       </div>
       <div>
-        {sortedContainer.slice(0, answerLimit).map((answer) => {
+        {answerContainer.map((answer) => {
           return (
             <p
               style={{ fontSize: "13px" }}
@@ -83,7 +87,8 @@ const QuestionItem = ({
           );
         })}
       </div>
-      <span style={ {fontWeight: '550', textDecoration: 'underline'} } className='clickable' onClick={sortedContainer.slice(0, answerLimit).length < sortedContainer.length ? () => { showMoreAnswers(sortedContainer.length) } : showLessAnswers }>{sortedContainer.slice(0, answerLimit).length < sortedContainer.length ? 'See More Answers' : sortedContainer.slice(0, answerLimit).length > 2 ? 'Collapse Answers' : ''}</span>
+      <span id={questionId} style={ {fontWeight: '550', textDecoration: 'underline'} } className='clickable' onClick={expandAnswers.includes(Number(questionId)) ? showLessAnswers : showMoreAnswers }>{sortedContainer.length <= 2 ? '' : expandAnswers.includes(Number(questionId)) ? 'Collapse Answers' : 'See More Answers'}</span>
+
       <AddAnswer questionId={questionId} productName={productName} questionBody={question.question_body} addAnswerTo={addAnswerTo} onClick={closeAddAnswer} onSubmit={handleSubmitAnswer}/>
     </div>
   );

--- a/client/src/components/QA/QuestionList.jsx
+++ b/client/src/components/QA/QuestionList.jsx
@@ -26,6 +26,7 @@ const QuestionList = (props) => {
           handleSubmitAnswer={props.handleSubmitAnswer}
           showMoreAnswers={props.showMoreAnswers}
           showLessAnswers={props.showLessAnswers}
+          expandAnswers={props.expandAnswers}
         />
       ))}
       <div className="questionButtons">

--- a/client/src/components/QA/QuestionView.jsx
+++ b/client/src/components/QA/QuestionView.jsx
@@ -20,7 +20,8 @@ class QuestionView extends React.Component {
       addQuestionVisisble: 'hidden',
       moreQuestionsVisible: 'visible',
       answerReported: [],
-      addAnswerTo: 0
+      addAnswerTo: 0,
+      expandAnswers: []
     };
 
     this.handleAddQuestion = this.handleAddQuestion.bind(this);
@@ -162,15 +163,19 @@ class QuestionView extends React.Component {
     .catch((err) => { throw err; });
   }
 
-  showMoreAnswers(len) {
+  showMoreAnswers(event) {
+    let container = [...this.state.expandAnswers, Number(event.target.id)]
     this.setState({
-      shownAnswers: len
+      expandAnswers: container
     });
   }
 
-  showLessAnswers() {
+  showLessAnswers(event) {
+    let idx = this.state.expandAnswers.indexOf(Number(event.target.id));
+
+    let container = this.state.expandAnswers.splice(idx, 1)
     this.setState({
-      shownAnswers: 2
+      expandedAnswers: container
     });
   }
 
@@ -185,7 +190,7 @@ class QuestionView extends React.Component {
         <div data-testid='question-view' className="qaComponent">
           <h2>Questions & Answers</h2>
           <QuestionSearch onSearch={this.searchQuestionList}/>
-          <QuestionList questions={this.state.searchedQuestions} answerLimit={this.state.shownAnswers} onClick={this.loadMoreQuestions} showQuestion={this.showAddQuestion} markQuestionHelpful={this.markQuestionHelpful} markAnswerHelpful={this.markAnswerHelpful} visible={this.state.moreQuestionsVisible} reportAnswer={this.reportAnswer} answerReported={this.state.answerReported} productName={this.props.productName} addAnswerTo={this.state.addAnswerTo} showAddAnswer={this.showAddAnswer} closeAddAnswer={this.closeAddAnswer} handleSubmitAnswer={this.handleSubmitAnswer} showMoreAnswers={this.showMoreAnswers} showLessAnswers={this.showLessAnswers}/>
+          <QuestionList questions={this.state.searchedQuestions} answerLimit={this.state.shownAnswers} onClick={this.loadMoreQuestions} showQuestion={this.showAddQuestion} markQuestionHelpful={this.markQuestionHelpful} markAnswerHelpful={this.markAnswerHelpful} visible={this.state.moreQuestionsVisible} reportAnswer={this.reportAnswer} answerReported={this.state.answerReported} productName={this.props.productName} addAnswerTo={this.state.addAnswerTo} showAddAnswer={this.showAddAnswer} closeAddAnswer={this.closeAddAnswer} handleSubmitAnswer={this.handleSubmitAnswer} showMoreAnswers={this.showMoreAnswers} showLessAnswers={this.showLessAnswers} expandAnswers={this.state.expandAnswers}/>
           <AddQuestion addQuestion={this.handleAddQuestion} visible={this.state.addQuestionVisisble} onClick={this.closeAddQuestion}/>
         </div>
       </div>


### PR DESCRIPTION
The bug was: when we clicked 'see more answers' it'd expand every answer list, so that every answer of every question was visible and not just within the QuestionItem you clicked on. 

I fixed it by: setting each span's element ID to the questionID it was associated with, and then passing this ID into an array in state upon clicking See More Answers. When rendering the answers, we check if the current question ID is in that array. If it is, we render every one of its answers and if not we render 2 (the default number). When we click 'collapse answers' it removes the questionID from the array, so when its re-rendered it'll only have two answers shown again.  If there are two or fewer answers, the span won't appear. 