### PR TITLE
styling and ratings error

### DIFF
--- a/client/dist/styles.css
+++ b/client/dist/styles.css
@@ -138,7 +138,6 @@ OVERVIEW
 .ProductCategory {
   color: rgb(75, 75, 75);
   text-transform: uppercase;
-  margin-bottom: 1em;
   font-size: 130%;
 }
 
@@ -373,6 +372,7 @@ OVERVIEW
   font-weight: 600;
   font-size: 110%;
   color: rgb(65, 65, 65);
+  background-color: rgb(240, 240, 240);
   padding: 12px 50px;
   margin: 5px;
   border: 0;
@@ -394,6 +394,7 @@ OVERVIEW
   font-weight: 600;
   font-size: 110%;
   color: rgb(65, 65, 65);
+  background-color: rgb(240, 240, 240);
   width: 110px;
   padding: 12px 30px;
   margin: 5px;
@@ -492,7 +493,7 @@ OVERVIEW
 }
 
 .ShareComponent .fa-creative-commons-share {
-  color: #00112c;
+  color: #474747;
 }
 
 /*

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -40,8 +40,12 @@ class App extends React.Component {
   handleGetRatings(id) {
     axios.get(`https://app-hrsei-api.herokuapp.com/api/fec2/hr-nyc/reviews/meta`, { headers: {Authorization: API_KEY}, params: {product_id: id}})
       .then((response) => {
+        let ratings = response.data;
+        if (JSON.stringify(ratings.ratings) === JSON.stringify({})) {
+          ratings.ratings = { 0: '1', 1: '0', 2: '0', 3: '0', 4: '0', 5: '0'};
+        }
         this.setState({
-          productRatings: response.data
+          productRatings: ratings
         })
       })
       .catch((error) => {

--- a/client/src/components/Overview/ImageGallery.jsx
+++ b/client/src/components/Overview/ImageGallery.jsx
@@ -6,7 +6,8 @@ class ImageGallery extends React.Component {
     this.state = {
       selectedImage: this.props.currentPhoto,
       selectedImageIndex: 0,
-      showModal: false
+      showModal: false,
+      nOfStylePhotos: this.props.selectedStylePhotos.length
     }
 
     this.handleCarouselNext = this.handleCarouselNext.bind(this);
@@ -20,7 +21,7 @@ class ImageGallery extends React.Component {
   
   componentDidUpdate(prevProps) {
     if (this.props.currentPhoto !== prevProps.currentPhoto) {
-      this.setState({selectedImage: this.props.currentPhoto});
+      this.setState({selectedImage: this.props.currentPhoto, nOfStylePhotos: this.props.selectedStylePhotos.length});
     }
   }
 
@@ -69,14 +70,14 @@ class ImageGallery extends React.Component {
     return(
       <div className="ImageGalleryContainer">
         <div className="ImageContainer">
-          <i className="fas fa-angle-left fa-3x" onClick={this.handlePreviousImage} />
+          <i className="fas fa-angle-left fa-3x" onClick={this.handlePreviousImage} style={{ display: this.state.nOfStylePhotos > 2 ? 'block' : 'none' }}/>
           <div className="SelectedImageContainer">
             <img className="SelectedImage" src={this.state.selectedImage} alt={this.props.selectedStyle.name} onClick={this.handleExpandImage}/>
             <div className="ImageModal" style={{ display: this.state.showModal ? 'flex' : 'none' }}>
               <img className="SelectedImageModal" src={this.state.selectedImage} alt={this.props.selectedStyle.name} onClick={this.handleCloseExpandedImage}/>
             </div>
           </div>
-          <i className="fas fa-angle-right fa-3x" onClick={this.handleNextImage} />
+          <i className="fas fa-angle-right fa-3x" onClick={this.handleNextImage} style={{ display: this.state.nOfStylePhotos > 2 ? 'block' : 'none' }}/>
         </div>
         <div className="ThumbnailContainer">
           <div className="ThumbnailCarouselContainer">
@@ -96,7 +97,7 @@ class ImageGallery extends React.Component {
             ))}
             </div>
           </div>
-          <div className="CarouselNav">
+          <div className="CarouselNav" style={{ display: this.state.nOfStylePhotos > 6 ? 'block' : 'none' }}>
             <i className="fas fa-angle-left fa-2x" onClick={this.handleCarouselPrevious} />
             <i className="fas fa-angle-right fa-2x" onClick={this.handleCarouselNext} />
           </div>

--- a/client/src/components/RatingsAndReviews/RatingsAndReviews.jsx
+++ b/client/src/components/RatingsAndReviews/RatingsAndReviews.jsx
@@ -138,7 +138,7 @@ class RatingsAndReviews extends React.Component {
               filter={this.state.filter}
             />
             <br/>
-            <ProductBreakdown productRatings={productRatings}/>
+            {productRatings.characteristics.Quality.value !== null && <ProductBreakdown productRatings={productRatings}/>}
           </div>
         }
         <ReviewList


### PR DESCRIPTION
hey @ks10825n @kyelindholm 

- Added background color to add to cart size and quantity selectors (they used to have a color and went white at some point)
- Refactored Image Gallery so the cycling arrows on the current photo only appear if there is more than one photo for that style.
- Refactored Image Gallery so the cycling arrows on the carousel only appear if there are more than 6 photos for that style.
- Refactored App.js and RatingsAndReviews.js to handle products with no reviews. 

Before, if you searched a product and it had no reviews, several components inside the Ratings and Reviews component would break, and would cause the rating (stars) component to also break. When you searched a different product that did have reviews, the stars component would show 0 stars. 

To reproduce this bug, search for 'infinity'. Infinity Stone has no reviews, the rating is an empty object which breaks RatingBreakdown.js because you are calling reduce on an empty object. It also breaks ProductBreakdown because you are calling the property .characteristics.Comfort.value, which is undefined in the API responses for products with no reviews. If you then search camo, the Camo Onesie will now have no stars, and any subsequent search will not show star ratings even if they have them.

To solve this, when receiving a response from the getRatings request, if the .ratings property is an empty object, it assigns it the default value that we used in util/ratingAverage.js (object with 0 set to 1 and everything else set to 0). This fixed RatingBreakdown.js, but not ProductBreakdown. To fix ProductBreakdown, made the ProductBreakdown component conditionally render if ratings.characteristics.Quality.value !== null (for some reason, a product with no reviews has quality.value set to null, however comfort does not exist at all).

You are welcome to refactor this into a better implementation @ks10825n if you wish to, this was the quickest and least invasive fix I could think of.